### PR TITLE
Initial Unix UDS HttpClient library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 9.0.x
+    - run: dotnet build -c Release
+    - run: dotnet test -c Release --no-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ jobs:
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 9.0.x
-    - run: dotnet build -c Release
-    - run: dotnet test -c Release --no-build
+    - run: dotnet build src/UnixDomainSockets.HttpClient/UnixDomainSockets.HttpClient.csproj -c Release
+    - run: dotnet test tests/UnixDomainSockets.HttpClient.Tests/UnixDomainSockets.HttpClient.Tests.csproj -c Release --no-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+on:
+  push:
+    tags: [ 'v*.*.*' ]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 9.0.x
+    - run: dotnet pack -c Release -o .artifacts /p:ContinuousIntegrationBuild=true
+    - run: dotnet nuget push .artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,5 +11,5 @@ jobs:
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 9.0.x
-    - run: dotnet pack -c Release -o .artifacts /p:ContinuousIntegrationBuild=true
+    - run: dotnet pack src/UnixDomainSockets.HttpClient/UnixDomainSockets.HttpClient.csproj -c Release -o .artifacts /p:ContinuousIntegrationBuild=true
     - run: dotnet nuget push .artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## 0.1.0 - Initial release

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Use preview because we target net9.0 preview -->
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(MSBuildProjectName.Contains('Tests')) or $(MSBuildProjectName.Contains('UdsMinimalApi'))">
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
-# unix-domain-sockets-httpclient
+# Unix Domain Sockets HttpClient
 
-Cliente HTTP para Linux que usa Unix Domain Sockets (UDS) por baixo do HttpClient, reduzindo latência e overhead de loopback/TCP entre processos no mesmo host.
+HttpClient sobre Unix Domain Sockets para .NET. Baixa latência intra-host, zero dependências, pronto para AOT/Trimming.
 
-Implementado com SocketsHttpHandler.ConnectCallback, compatível com AOT/Trimming e System.Text.Json com source‑generation.
+```
+var client = UnixHttpClientFactory.For("/sockets/app.sock", TimeSpan.FromSeconds(5));
+var pong = await client.GetFromJsonAsync<PingDto>("/ping", TestJsonContext.Default.PingDto);
+```
+
+Requisitos: Linux; em Windows lança NotSupportedException.
+
+Veja exemplos de configuração do servidor Kestrel com sockets Unix no diretório `samples`.
+
+Distribuído sob licença MIT.

--- a/samples/UdsMinimalApi/Program.cs
+++ b/samples/UdsMinimalApi/Program.cs
@@ -1,0 +1,30 @@
+using UnixDomainSockets.HttpClient;
+using System.Net.Http.Json;
+
+var socketPath = "/tmp/uds-sample.sock";
+var builder = WebApplication.CreateBuilder(args);
+
+builder.WebHost.UseKestrel(opts =>
+{
+    opts.ListenUnixSocket(socketPath);
+});
+
+var app = builder.Build();
+
+app.MapGet("/time", () => Results.Json(new { time = DateTimeOffset.UtcNow }));
+app.MapPost("/sum", (int a, int b) => Results.Json(new { sum = a + b }));
+
+app.Lifetime.ApplicationStarted.Register(async () =>
+{
+    if (!OperatingSystem.IsWindows())
+    {
+        File.SetUnixFileMode(socketPath, UnixFileMode.UserRead | UnixFileMode.UserWrite |
+            UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.OtherRead | UnixFileMode.OtherWrite);
+    }
+
+    using var client = UnixHttpClientFactory.For(socketPath);
+    var time = await client.GetFromJsonAsync<object>("/time");
+    Console.WriteLine($"Time: {time}");
+});
+
+await app.RunAsync();

--- a/samples/UdsMinimalApi/UdsMinimalApi.csproj
+++ b/samples/UdsMinimalApi/UdsMinimalApi.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/UnixDomainSockets.HttpClient/UnixDomainSockets.HttpClient.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/UnixDomainSockets.HttpClient/GlobalUsings.cs
+++ b/src/UnixDomainSockets.HttpClient/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using System;
+global using System.Net.Http;
+global using System.Net.Sockets;

--- a/src/UnixDomainSockets.HttpClient/UnixDomainSockets.HttpClient.csproj
+++ b/src/UnixDomainSockets.HttpClient/UnixDomainSockets.HttpClient.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>UnixDomainSockets.HttpClient</PackageId>
+    <Authors>YourName</Authors>
+    <Description>HttpClient via Unix Domain Sockets for .NET.</Description>
+    <RepositoryUrl>https://example.com/repo</RepositoryUrl>
+    <PackageTags>dotnet;httpclient;unix-domain-sockets;uds;linux;aot;trimming;performance</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+</Project>

--- a/src/UnixDomainSockets.HttpClient/UnixHttpClientFactory.cs
+++ b/src/UnixDomainSockets.HttpClient/UnixHttpClientFactory.cs
@@ -1,0 +1,72 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+
+namespace UnixDomainSockets.HttpClient;
+
+/// <summary>
+/// Factory for <see cref="System.Net.Http.HttpClient"/> instances communicating over Unix Domain Sockets.
+/// </summary>
+public static class UnixHttpClientFactory
+{
+    /// <summary>
+    /// Creates an <see cref="System.Net.Http.HttpClient"/> for communicating with a server listening on the provided socket path.
+    /// </summary>
+    /// <param name="socketPath">Path to the Unix domain socket.</param>
+    /// <param name="timeout">Optional timeout applied to the client.</param>
+    /// <param name="maxConnections">Maximum simultaneous connections.</param>
+    /// <returns>Configured <see cref="System.Net.Http.HttpClient"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="socketPath"/> is null or empty.</exception>
+    /// <exception cref="NotSupportedException">Thrown on non-Unix platforms.</exception>
+    public static System.Net.Http.HttpClient For(string socketPath, TimeSpan? timeout = null, int maxConnections = 256)
+    {
+        if (string.IsNullOrWhiteSpace(socketPath))
+        {
+            throw new ArgumentException("Socket path must be provided", nameof(socketPath));
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            throw new NotSupportedException("Unix Domain Sockets only supported on Unix-like systems");
+        }
+
+        var handler = new SocketsHttpHandler
+        {
+            ConnectCallback = async (context, cancellationToken) =>
+            {
+                var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                try
+                {
+                    var endpoint = new UnixDomainSocketEndPoint(socketPath);
+                    await socket.ConnectAsync(endpoint, cancellationToken).ConfigureAwait(false);
+                    return new NetworkStream(socket, ownsSocket: true);
+                }
+                catch
+                {
+                    socket.Dispose();
+                    throw new HttpRequestException($"Failed to connect to socket '{socketPath}'");
+                }
+            },
+            MaxConnectionsPerServer = maxConnections
+        };
+
+        var client = new System.Net.Http.HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://localhost/"),
+        };
+
+        if (timeout.HasValue)
+        {
+            client.Timeout = timeout.Value;
+        }
+
+        return client;
+    }
+
+    /// <summary>
+    /// Creates a read-only <see cref="System.Net.Http.HttpClient"/>. Only GET requests should be performed using this instance.
+    /// This method is functionally identical to <see cref="For(string, TimeSpan?, int)"/> but exists to document intent.
+    /// </summary>
+    public static System.Net.Http.HttpClient ForReadonly(string socketPath, TimeSpan? timeout = null)
+        => For(socketPath, timeout);
+}

--- a/tests/UnixDomainSockets.HttpClient.Tests/HttpClientFactoryTests.cs
+++ b/tests/UnixDomainSockets.HttpClient.Tests/HttpClientFactoryTests.cs
@@ -1,0 +1,58 @@
+using System.Net.Http.Json;
+using Xunit;
+
+namespace UnixDomainSockets.HttpClient.Tests;
+
+public class HttpClientFactoryTests : IClassFixture<UdsServerFixture>
+{
+    private readonly UdsServerFixture _fixture;
+
+    public HttpClientFactoryTests(UdsServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Can_Get_Ping()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(() => Task.Run(() => UnixHttpClientFactory.For(_fixture.SocketPath)));
+            return;
+        }
+
+        using var client = UnixHttpClientFactory.For(_fixture.SocketPath, TimeSpan.FromSeconds(5));
+        var result = await client.GetFromJsonAsync<PingDto>("/ping", TestJsonContext.Default.PingDto);
+        Assert.NotNull(result);
+        Assert.True(result!.ok);
+    }
+
+    [Fact]
+    public async Task Can_Post_Echo()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var client = UnixHttpClientFactory.For(_fixture.SocketPath);
+        var payload = new { message = "hi" };
+        var response = await client.PostAsJsonAsync("/echo", payload);
+        response.EnsureSuccessStatusCode();
+        var echoed = await response.Content.ReadFromJsonAsync<object>(TestJsonContext.Default.Object);
+        Assert.NotNull(echoed);
+    }
+
+    [Fact]
+    public async Task Invalid_Path_Throws_HttpRequestException()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var invalidPath = "/tmp/does-not-exist.sock";
+        using var client = UnixHttpClientFactory.For(invalidPath, TimeSpan.FromSeconds(1));
+        await Assert.ThrowsAsync<HttpRequestException>(async () => await client.GetAsync("/ping"));
+    }
+}

--- a/tests/UnixDomainSockets.HttpClient.Tests/TestJsonContext.cs
+++ b/tests/UnixDomainSockets.HttpClient.Tests/TestJsonContext.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace UnixDomainSockets.HttpClient.Tests;
+
+[JsonSerializable(typeof(PingDto))]
+[JsonSerializable(typeof(object))]
+public partial class TestJsonContext : JsonSerializerContext
+{
+}
+
+public record PingDto(bool ok);

--- a/tests/UnixDomainSockets.HttpClient.Tests/UdsServerFixture.cs
+++ b/tests/UnixDomainSockets.HttpClient.Tests/UdsServerFixture.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using System.Net;
+using System.Net.Sockets;
+
+namespace UnixDomainSockets.HttpClient.Tests;
+
+public sealed class UdsServerFixture : IAsyncLifetime
+{
+    public string SocketPath { get; } = $"/tmp/uds-httpclient-tests-{Guid.NewGuid():N}.sock";
+    private IHost? _host;
+
+    public async Task InitializeAsync()
+    {
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseKestrel(options =>
+                {
+                    options.ListenUnixSocket(SocketPath);
+                });
+                webBuilder.Configure(app =>
+                {
+                    app.MapGet("/ping", () => Results.Json(new { ok = true }));
+                    app.MapPost("/echo", async (HttpContext ctx) =>
+                    {
+                        var body = await ctx.Request.ReadFromJsonAsync<object>();
+                        await ctx.Response.WriteAsJsonAsync(body);
+                    });
+                });
+            });
+
+        _host = builder.Build();
+        await _host.StartAsync();
+
+        // ensure other processes can access socket
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(SocketPath, UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.OtherRead | UnixFileMode.OtherWrite);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_host is not null)
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        try
+        {
+            File.Delete(SocketPath);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/tests/UnixDomainSockets.HttpClient.Tests/UnixDomainSockets.HttpClient.Tests.csproj
+++ b/tests/UnixDomainSockets.HttpClient.Tests/UnixDomainSockets.HttpClient.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/UnixDomainSockets.HttpClient/UnixDomainSockets.HttpClient.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add reusable HttpClient factory for Unix Domain Sockets
- provide unit tests and minimal API sample
- enable GitHub Actions CI and release
- include repository docs and configuration

## Testing
- `dotnet build -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test tests/UnixDomainSockets.HttpClient.Tests/UnixDomainSockets.HttpClient.Tests.csproj -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688bc516688c832f82dd111215c958f3